### PR TITLE
refactor - stop deleting payload keys inside validation

### DIFF
--- a/schema/downstreamCommand.js
+++ b/schema/downstreamCommand.js
@@ -31,19 +31,21 @@ class DownstreamCommand {
   }
   validateRequest() {
     if (!this.requestSchema || skip) return validationSkipped(this.type);
+    const requestSchemaBody = {...this.requestSchema}; 
     this.requestSchema = new Schema(this.requestSchema);
     if (!this.requestSchema.validate(this.payload)) {
       const message = this.requestSchema.getValidationErrors();
       throw new FaultHandled(message, { code: ERROR_CODES.REQUEST_FAULT, layer: this.type, });
-    } else this.payload = this.requestSchema.getBody(this.payload.strict === false);
+    } else this.payload = this.requestSchema.getBody(requestSchemaBody.strict === false);
   }
   validateResponse(response) {
     if (!this.responseSchema) return validationSkipped(this.type);
+    const responseSchemaBody = {...this.responseSchema};
     this.responseSchema = new Schema(this.responseSchema);
     if (!this.responseSchema.validate(response)) {
       const message = this.responseSchema.getValidationErrors();
       throw new FaultHandled(message, { code: ERROR_CODES.RESPONSE_FAULT, layer: this.type, });
-    } else this.payload = this.responseSchema.getBody(this.payload.strict === false);
+    } else this.payload = this.responseSchema.getBody(responseSchemaBody.strict === false);
   }
   getErrorCataloged(code, message) {
     const catalogedError = this.errorCatalog[code];

--- a/schema/downstreamCommand.js
+++ b/schema/downstreamCommand.js
@@ -35,7 +35,7 @@ class DownstreamCommand {
     if (!this.requestSchema.validate(this.payload)) {
       const message = this.requestSchema.getValidationErrors();
       throw new FaultHandled(message, { code: ERROR_CODES.REQUEST_FAULT, layer: this.type, });
-    } else this.payload = this.requestSchema.getBody();
+    } else this.payload = this.requestSchema.getBody(this.payload.strict === false);
   }
   validateResponse(response) {
     if (!this.responseSchema) return validationSkipped(this.type);
@@ -43,7 +43,7 @@ class DownstreamCommand {
     if (!this.responseSchema.validate(response)) {
       const message = this.responseSchema.getValidationErrors();
       throw new FaultHandled(message, { code: ERROR_CODES.RESPONSE_FAULT, layer: this.type, });
-    } else this.payload = this.responseSchema.getBody();
+    } else this.payload = this.responseSchema.getBody(this.payload.strict === false);
   }
   getErrorCataloged(code, message) {
     const catalogedError = this.errorCatalog[code];

--- a/schema/downstreamEvent.js
+++ b/schema/downstreamEvent.js
@@ -35,7 +35,7 @@ class DownstreamEvent {
     if (!this.schema.validate(this.payload)) {
       const message = this.schema.getValidationErrors();
       throw new FaultHandled(message, { code: ERROR_CODES.CREATION_FAULT, layer: this.type, });
-    } else this.payload = this.schema.getBody();
+    } else this.payload = this.schema.getBody(this.payload.strict === false);
   }
   publish() {
     customEvent(this);

--- a/schema/downstreamEvent.js
+++ b/schema/downstreamEvent.js
@@ -31,11 +31,12 @@ class DownstreamEvent {
   }
   validate() {
     if (!this.schema || skip) return validationSkipped(this.type);
+    const schemaBody = {...this.schema} 
     this.schema = new Schema(this.schema);
     if (!this.schema.validate(this.payload)) {
       const message = this.schema.getValidationErrors();
       throw new FaultHandled(message, { code: ERROR_CODES.CREATION_FAULT, layer: this.type, });
-    } else this.payload = this.schema.getBody(this.payload.strict === false);
+    } else this.payload = this.schema.getBody(schemaBody.strict === false);
   }
   publish() {
     customEvent(this);

--- a/schema/inputValidation.js
+++ b/schema/inputValidation.js
@@ -34,7 +34,7 @@ class InputValidation {
       this.payload = { error: error.get(), originalPayload: this.payload };
       this.publish();
       throw error;
-    } else this.payload = this.schema.getBody();
+    } else this.payload = this.schema.getBody(this.payload.strict === false);
   }
   publish() { if (this.source === 'CLIENT_COMMAND') customEvent(this) }
   get() { return this.payload }

--- a/schema/inputValidation.js
+++ b/schema/inputValidation.js
@@ -26,6 +26,7 @@ class InputValidation {
   validate() {
     if (skip) return validationSkipped(this.type);
     if (!this.schema) throw new FaultHandled('Missing schema', { code: ERROR_CODES.CREATION_FAULT, layer: this.type })
+    const schemaBody = {...this.schema}
     this.schema = new Schema(this.schema);
     if (!this.schema.validate(this.payload)) {
       const message = this.schema.getValidationErrors();
@@ -34,7 +35,7 @@ class InputValidation {
       this.payload = { error: error.get(), originalPayload: this.payload };
       this.publish();
       throw error;
-    } else this.payload = this.schema.getBody(this.payload.strict === false);
+    } else this.payload = this.schema.getBody(schemaBody.strict === false);
   }
   publish() { if (this.source === 'CLIENT_COMMAND') customEvent(this) }
   get() { return this.payload }

--- a/schema/metricEvent.js
+++ b/schema/metricEvent.js
@@ -28,7 +28,7 @@ class MetricEvent {
     if (!this.schema.validate(this.payload)) {
       const message = this.schema.getValidationErrors();
       throw new FaultHandled(message, { code: ERROR_CODES.CREATION_FAULT, layer: this.type, });
-    } else this.payload = this.schema.getBody();
+    } else this.payload = this.schema.getBody(this.payload.strict === false);
   }
   publish() {
     customEvent(this);

--- a/schema/metricEvent.js
+++ b/schema/metricEvent.js
@@ -24,11 +24,12 @@ class MetricEvent {
   }
   validate() {
     if (!this.schema || skip) return validationSkipped(this.type);
+    const schemaBody = {...this.schema}
     this.schema = new Schema(this.schema);
     if (!this.schema.validate(this.payload)) {
       const message = this.schema.getValidationErrors();
       throw new FaultHandled(message, { code: ERROR_CODES.CREATION_FAULT, layer: this.type, });
-    } else this.payload = this.schema.getBody(this.payload.strict === false);
+    } else this.payload = this.schema.getBody(schemaBody.strict === false);
   }
   publish() {
     customEvent(this);


### PR DESCRIPTION
Stop deleting payload keys inside validation if are not declared in schema when using `{strict:false}`